### PR TITLE
Fixing some wrong Unite sources on README

### DIFF
--- a/README
+++ b/README
@@ -29,10 +29,10 @@ unite /log
   :Unite rails/log
 
 unite /public/javascripts
-  :Unite rails/javascripts
+  :Unite rails/javascript
 
 unite /public/stylesheets
-  :Unite rails/stylesheets
+  :Unite rails/stylesheet
 
 unite bundle's commands
   :Unite rails/bundle
@@ -44,7 +44,7 @@ unite bundled gems
 == maybe ==
 
   unite routes 
-    :Unite rails/routes
+    :Unite rails/route
 
   unite root
     :Unite rails/root


### PR DESCRIPTION
Some Unite sources on the README were on the plural, but it gives an error. It works on singular.
- Changed rails/javascripts to rails/javascript
- Changed rails/stylesheets to rails/stylesheet
- Changed rails/routes to rails/route
